### PR TITLE
Bumping freedesktop-desktop-entry to 0.7.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-freedesktop-desktop-entry = "0.7.5"
+freedesktop-desktop-entry = "0.7.8"
 mime = "0.3.17"
 quick-xml = "0.37.1"
 xdg = "2.5.2"


### PR DESCRIPTION
part of https://github.com/pop-os/freedesktop-desktop-entry/issues/41