### PR TITLE
chore: use freedesktop-desktop-entry for parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 rust-version = "1.85"
 
 [dependencies]
-freedesktop-desktop-entry = "0.7.19"
+freedesktop-desktop-entry = "0.8.1"
 mime = "0.3.17"
 quick-xml = "0.38"
 xdg = "3.0"

--- a/fixtures/mimeapps-1.list
+++ b/fixtures/mimeapps-1.list
@@ -1,0 +1,9 @@
+[Default Applications]
+text/plain=com.system76.CosmicEdit.desktop
+text/css=com.system76.CosmicEdit.desktop
+[Added Associations]
+text/plain=com.system76.CosmicEdit.desktop
+text/css=com.system76.CosmicEdit.desktop
+[Removed Associations]
+text/plain=com.system76.CosmicEdit.desktop
+text/css=com.system76.CosmicEdit.desktop

--- a/fixtures/mimeapps-2.list
+++ b/fixtures/mimeapps-2.list
@@ -1,0 +1,9 @@
+[Default Applications]
+text/plain=com.system76.CosmicEdit.desktop
+text/html=com.system76.CosmicEdit.desktop
+[Added Associations]
+text/plain=com.system76.CosmicEdit.desktop
+text/html=com.system76.CosmicEdit.desktop
+[Removed Associations]
+text/plain=com.system76.CosmicEdit.desktop
+text/html=com.system76.CosmicEdit.desktop

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,3 +109,40 @@ fn apply_existing_paths(
 
     paths
 }
+
+#[cfg(test)]
+mod test {
+    use mime::Mime;
+
+    use crate::List;
+
+    #[test]
+    fn can_load_multiple_mimeapps_files() {
+        let mut list = List::default();
+        let paths = vec!["fixtures/mimeapps-1.list", "fixtures/mimeapps-2.list"];
+
+        list.load_from_paths(&paths);
+
+        assert_eq!(list.default_apps.len(), 3);
+        assert_eq!(list.added_associations.len(), 3);
+        assert_eq!(list.removed_associations.len(), 3);
+    }
+
+    #[test]
+    fn can_parse_mime_type() {
+        let mut list = List::default();
+        let paths = vec!["fixtures/mimeapps-1.list"];
+
+        list.load_from_paths(&paths);
+
+        assert_eq!(list.default_apps.len(), 2);
+
+        let text_plain = "text/plain".parse::<Mime>().unwrap();
+        let default_apps = list.default_app_for(&text_plain).unwrap();
+        assert_eq!(default_apps.len(), 1);
+        assert_eq!(
+            default_apps[0].to_string(),
+            "com.system76.CosmicEdit.desktop"
+        );
+    }
+}

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,6 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: MPL-2.0
 
+use freedesktop_desktop_entry::{Line, parse_line};
 use mime::Mime;
 use std::{collections::BTreeMap, io::Read, path::Path, str::Lines};
 
@@ -155,26 +156,19 @@ impl<'a> Iterator for Iter<'a> {
         loop {
             let line = self.lines.next()?.trim();
 
-            if line.is_empty() {
-                continue;
-            }
-
-            match line {
-                "[Default Applications]" => {
-                    self.active_property = Some(AstMap::DefaultApplications)
-                }
-                "[Added Associations]" => self.active_property = Some(AstMap::AddedAssociations),
-                "[Removed Associations]" => {
-                    self.active_property = Some(AstMap::RemovedAssociations)
-                }
-                handler => {
-                    if handler.starts_with("#") {
-                        continue;
+            match parse_line(line) {
+                Ok(Line::Group(group)) => match group {
+                    "Default Applications" => {
+                        self.active_property = Some(AstMap::DefaultApplications)
                     }
-
-                    if let Some((property, (mime, apps))) =
-                        self.active_property.zip(handler.split_once('='))
-                    {
+                    "Added Associations" => self.active_property = Some(AstMap::AddedAssociations),
+                    "Removed Associations" => {
+                        self.active_property = Some(AstMap::RemovedAssociations)
+                    }
+                    _ => self.active_property = None,
+                },
+                Ok(Line::Entry(mime, apps)) => {
+                    if let Some(property) = self.active_property {
                         return Some(match property {
                             AstMap::AddedAssociations => Ast::AddAssociation(mime, apps),
                             AstMap::DefaultApplications => Ast::DefaultApp(mime, apps),
@@ -182,6 +176,7 @@ impl<'a> Iterator for Iter<'a> {
                         });
                     }
                 }
+                _ => (),
             }
         }
     }


### PR DESCRIPTION
This is in regards to the broader idea of using `freedesktop-desktop-entry` for all desktop entry like parsing across Cosmic to keep things consistent. I added tests to ensure this did not break anything.